### PR TITLE
Refactored notification broadcasting

### DIFF
--- a/WebScrapper/Adapters/SmtpClientAdapter.cs
+++ b/WebScrapper/Adapters/SmtpClientAdapter.cs
@@ -1,0 +1,60 @@
+﻿using MailKit;
+using MailKit.Net.Smtp;
+
+using MimeKit;
+
+namespace WebScrapper.Adapters;
+
+public class SmtpClientAdapter : IDisposable
+{
+    private readonly SmtpClient _smtpClient;
+    private readonly SmtpSettings _smtpSettings;
+
+    public SmtpClientAdapter(SmtpClient smtpClient, SmtpSettings smtpSettings)
+    {
+        this._smtpClient = smtpClient;
+        this._smtpSettings = smtpSettings;
+    }
+
+
+    public bool IsConnected => _smtpClient.IsConnected;
+    public bool IsAuthenticated => _smtpClient.IsAuthenticated;
+
+    public async Task ConnectAsync()
+    {
+        await _smtpClient.ConnectAsync(_smtpSettings.SmtpHost, _smtpSettings.SmtpPort, _smtpSettings.SecureSocketOptions);
+    }
+    public async Task AuthenticateAsync()
+    {
+        await _smtpClient.AuthenticateAsync(_smtpSettings.SenderEmail, _smtpSettings.SenderPassword);
+    }
+    public async Task<string> SendAsync(MimeMessage message, CancellationToken cancellationToken = default, ITransferProgress progress = null)
+    {
+        return await _smtpClient.SendAsync(message, cancellationToken, progress);
+    }
+
+
+
+    private bool disposedValue = false;
+    public void Dispose()
+    {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposedValue)
+        {
+            if (disposing)
+            {
+                // TODO: dispose managed state (managed objects)
+                _smtpClient.Dispose();
+            }
+
+            // TODO: free unmanaged resources (unmanaged objects) and override finalizer
+            // TODO: set large fields to null
+            disposedValue = true;
+        }
+    }
+}

--- a/WebScrapper/Common/WebScrapperConstants.cs
+++ b/WebScrapper/Common/WebScrapperConstants.cs
@@ -1,0 +1,6 @@
+﻿namespace WebScrapper.Common;
+
+public class WebScrapperConstants
+{
+    public const string SendEmailResiliencePipelineName = "Send-Email-Resilience-Pipeline";
+}

--- a/WebScrapper/Configuration/SmtpSettings.cs
+++ b/WebScrapper/Configuration/SmtpSettings.cs
@@ -2,6 +2,8 @@ using MailKit.Security;
 
 public class SmtpSettings
 {
+    public const string SectionName = "SmtpSettings";
+
     public string SenderEmail { get; set; } = string.Empty;
     public string SenderPassword { get; set; } = string.Empty;
     public string SmtpHost { get; set; } = string.Empty;

--- a/WebScrapper/Factories/Interfaces/ISmtpClientFactory.cs
+++ b/WebScrapper/Factories/Interfaces/ISmtpClientFactory.cs
@@ -1,0 +1,8 @@
+﻿using MailKit.Net.Smtp;
+
+namespace WebScrapper.Factories.Interfaces;
+
+public interface ISmtpClientFactory
+{
+    public Task<SmtpClient> CreateAsync();
+}

--- a/WebScrapper/Factories/Interfaces/ISmtpClientFactory.cs
+++ b/WebScrapper/Factories/Interfaces/ISmtpClientFactory.cs
@@ -1,8 +1,8 @@
-﻿using MailKit.Net.Smtp;
+﻿using WebScrapper.Adapters;
 
 namespace WebScrapper.Factories.Interfaces;
 
 public interface ISmtpClientFactory
 {
-    public Task<SmtpClient> CreateAsync();
+    public Task<SmtpClientAdapter> CreateAsync();
 }

--- a/WebScrapper/Factories/SmtpClientFactory.cs
+++ b/WebScrapper/Factories/SmtpClientFactory.cs
@@ -1,0 +1,54 @@
+﻿using MailKit.Net.Smtp;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using WebScrapper.Factories.Interfaces;
+
+namespace WebScrapper.Factories;
+
+public class SmtpClientFactory : ISmtpClientFactory
+{
+    private readonly SmtpSettings _smtpSettings;
+    private readonly ILogger<SmtpClientFactory> _logger;
+
+    public SmtpClientFactory(IOptions<SmtpSettings> smtpSettings, ILogger<SmtpClientFactory> logger)
+    {
+        _smtpSettings = smtpSettings.Value;
+        _logger = logger;
+    }
+
+    public async Task<SmtpClient> CreateAsync()
+    {
+        var smtpClient = new SmtpClient();
+        await ConnectAsync(smtpClient);
+        await AuthenticateAsync(smtpClient);
+
+        return smtpClient;
+    }
+
+    private async Task ConnectAsync(SmtpClient smtpClient)
+    {
+        try
+        {
+            await smtpClient.ConnectAsync(_smtpSettings.SmtpHost, _smtpSettings.SmtpPort, _smtpSettings.SecureSocketOptions);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, $"Error connecting SMTP client: {exception.Message}");
+            throw;
+        }
+    }
+    private async Task AuthenticateAsync(SmtpClient smtpClient)
+    {
+        try
+        {
+            await smtpClient.AuthenticateAsync(_smtpSettings.SenderEmail, _smtpSettings.SenderPassword);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, $"Error authenticating SMTP client: {exception.Message}");
+            throw;
+        }
+    }
+}

--- a/WebScrapper/Factories/SmtpClientFactory.cs
+++ b/WebScrapper/Factories/SmtpClientFactory.cs
@@ -3,6 +3,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
+using WebScrapper.Adapters;
 using WebScrapper.Factories.Interfaces;
 
 namespace WebScrapper.Factories;
@@ -19,20 +20,20 @@ public class SmtpClientFactory : ISmtpClientFactory
     }
 
 
-    public async Task<SmtpClient> CreateAsync()
+    public async Task<SmtpClientAdapter> CreateAsync()
     {
-        var smtpClient = new SmtpClient();
+        var smtpClient = new SmtpClientAdapter(new SmtpClient(), _smtpSettings);
         await ConnectAsync(smtpClient);
         await AuthenticateAsync(smtpClient);
 
         return smtpClient;
     }
 
-    private async Task ConnectAsync(SmtpClient smtpClient)
+    private async Task ConnectAsync(SmtpClientAdapter smtpClient)
     {
         try
         {
-            await smtpClient.ConnectAsync(_smtpSettings.SmtpHost, _smtpSettings.SmtpPort, _smtpSettings.SecureSocketOptions);
+            await smtpClient.ConnectAsync();
         }
         catch (Exception exception)
         {
@@ -40,11 +41,11 @@ public class SmtpClientFactory : ISmtpClientFactory
             throw;
         }
     }
-    private async Task AuthenticateAsync(SmtpClient smtpClient)
+    private async Task AuthenticateAsync(SmtpClientAdapter smtpClient)
     {
         try
         {
-            await smtpClient.AuthenticateAsync(_smtpSettings.SenderEmail, _smtpSettings.SenderPassword);
+            await smtpClient.AuthenticateAsync();
         }
         catch (Exception exception)
         {

--- a/WebScrapper/Factories/SmtpClientFactory.cs
+++ b/WebScrapper/Factories/SmtpClientFactory.cs
@@ -18,6 +18,7 @@ public class SmtpClientFactory : ISmtpClientFactory
         _logger = logger;
     }
 
+
     public async Task<SmtpClient> CreateAsync()
     {
         var smtpClient = new SmtpClient();

--- a/WebScrapper/Program.cs
+++ b/WebScrapper/Program.cs
@@ -41,7 +41,9 @@ var host = new HostBuilder()
             return client.GetDatabase("WebCrawlerDb");
         });
 
-        services.Configure<SmtpSettings>(configuration.GetSection("SmtpSettings"));
+        services.AddOptions<SmtpSettings>()
+            .Bind(configuration.GetSection(SmtpSettings.SectionName))
+            .ValidateOnStart();
 
         services.AddSingleton<ISmtpClientFactory, SmtpClientFactory>();
 

--- a/WebScrapper/Program.cs
+++ b/WebScrapper/Program.cs
@@ -2,7 +2,11 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+
 using MongoDB.Driver;
+
+using WebScrapper.Factories;
+using WebScrapper.Factories.Interfaces;
 using WebScrapper.Repositories;
 using WebScrapper.Repositories.Interfaces;
 using WebScrapper.Services;
@@ -33,6 +37,8 @@ var host = new HostBuilder()
         });
 
         services.Configure<SmtpSettings>(configuration.GetSection("SmtpSettings"));
+
+        services.AddSingleton<ISmtpClientFactory, SmtpClientFactory>();
 
         services.AddScoped<IAdsRepository, AdsRepository>();
         services.AddScoped<IScrapJobsRepository, ScrapJobsRepository>();

--- a/WebScrapper/Program.cs
+++ b/WebScrapper/Program.cs
@@ -15,6 +15,8 @@ using WebScrapper.Repositories.Interfaces;
 using WebScrapper.Services;
 using WebScrapper.Services.Interfaces;
 
+using static WebScrapper.Common.WebScrapperConstants;
+
 var host = new HostBuilder()
     .ConfigureAppConfiguration((context, config) =>
     {
@@ -43,7 +45,7 @@ var host = new HostBuilder()
 
         services.AddSingleton<ISmtpClientFactory, SmtpClientFactory>();
 
-        services.AddResiliencePipeline($"{nameof(SmtpRepository)}-pipeline", x =>
+        services.AddResiliencePipeline(SendEmailResiliencePipelineName, x =>
         {
             x.AddRetry(new RetryStrategyOptions
             {

--- a/WebScrapper/Repositories/SmtpRepository.cs
+++ b/WebScrapper/Repositories/SmtpRepository.cs
@@ -9,6 +9,8 @@ using WebScrapper.Entities;
 using WebScrapper.Factories.Interfaces;
 using WebScrapper.Repositories.Interfaces;
 
+using static WebScrapper.Common.WebScrapperConstants;
+
 namespace WebScrapper.Repositories;
 
 public class SmtpRepository : INotificationRepository
@@ -37,7 +39,7 @@ public class SmtpRepository : INotificationRepository
             SetEmailMetadata(notification, receiver, message);
             GetEmailBody(notification, message);
 
-            var resiliencePipeline = _resiliencePipelineProvider.GetPipeline($"{nameof(SmtpRepository)}-pipeline");
+            var resiliencePipeline = _resiliencePipelineProvider.GetPipeline(SendEmailResiliencePipelineName);
             await resiliencePipeline.ExecuteAsync(async _ =>
             {
                 try

--- a/WebScrapper/Repositories/SmtpRepository.cs
+++ b/WebScrapper/Repositories/SmtpRepository.cs
@@ -42,6 +42,12 @@ public class SmtpRepository : INotificationRepository
             var resiliencePipeline = _resiliencePipelineProvider.GetPipeline(SendEmailResiliencePipelineName);
             await resiliencePipeline.ExecuteAsync(async _ =>
             {
+                if (!smtpClient.IsConnected)
+                {
+                    await smtpClient.ConnectAsync();
+                    await smtpClient.AuthenticateAsync();
+                }
+
                 try
                 {
                     await smtpClient.SendAsync(message);

--- a/WebScrapper/WebScrapper.csproj
+++ b/WebScrapper/WebScrapper.csproj
@@ -15,9 +15,9 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.3.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.48.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.0.0" />
-    <PackageReference Include="Polly" Version="8.4.2" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
- Created an ```SmtpClientAdapter```
- Created an ```SmtpClientFactory``` to create a connected and authenticated client instead of the ```SmtpRepository``` because of single responsability
- Refactored the ```SmtpSettings``` registration
- Replaced Polly with Microsoft.Extensions.Http.Resilience

NOTE: The previous ```AsyncRetryPolicy``` logged a warning on each retry ("Retry {retryCount} for {receiverEmail} due to {exceptionMessage}"). This logging is now removed since it relied on local variables in ```SmtpRepository.SendNotificationAsync(Notification)```. If needed, this functionality can be restored. However, doing so would add verbosity and reduce code readability. 